### PR TITLE
Fix axios base URL

### DIFF
--- a/templates/src/boot/axios_request.js
+++ b/templates/src/boot/axios_request.js
@@ -13,7 +13,7 @@ function getBaseUrl (name) {
   return xhr.status === okStatus ? xhr.responseText : null
 }
 
-const baseurl = window.location.origin + '/'
+const baseurl = window.location.origin
 
 const axiosInstance = axios.create({
   baseURL: baseurl,


### PR DESCRIPTION
## Summary
- remove trailing slash from axios baseurl to avoid double slashes in requests

## Testing
- `yarn run lint` *(fails: package missing)*
- `npx quasar build -m spa`

------
https://chatgpt.com/codex/tasks/task_e_6882351c8b808330add21b36231d230b