### PR TITLE
Improve warehouse switching

### DIFF
--- a/templates/src/boot/axios_request.js
+++ b/templates/src/boot/axios_request.js
@@ -53,6 +53,7 @@ axiosInstanceAuth.interceptors.request.use(
       config.headers.put['Content-Type'] = 'application/json, charset="utf-8"'
       config.headers.token = LocalStorage.getItem('openid')
       config.headers.operator = LocalStorage.getItem('login_id')
+      config.headers.warehouse_id = LocalStorage.getItem('warehouse_id')
       config.headers.language = lang
       if (config.method === 'post' || config.method === 'patch' || config.method === 'put' || config.method === 'delete') {
         Loading.show()
@@ -200,6 +201,7 @@ axiosInstanceAuthScan.interceptors.request.use(
       config.headers.put['Content-Type'] = 'application/json, charset="utf-8"'
       config.headers.token = LocalStorage.getItem('openid')
       config.headers.operator = LocalStorage.getItem('login_id')
+      config.headers.warehouse_id = LocalStorage.getItem('warehouse_id')
       config.headers.language = lang
       if (config.method === 'post' || config.method === 'patch' || config.method === 'put' || config.method === 'delete') {
         Loading.show()
@@ -331,6 +333,7 @@ axiosInstance.interceptors.request.use(
   function (config) {
     config.headers.post['Content-Type'] = 'application/json, charset="utf-8"'
     config.headers.language = lang
+    config.headers.warehouse_id = LocalStorage.getItem('warehouse_id')
     if (config.method === 'post' || config.method === 'patch' || config.method === 'put' || config.method === 'delete') {
         Loading.show()
       }
@@ -444,6 +447,7 @@ axiosInstanceVersion.interceptors.request.use(
       if (config.method === 'post' || config.method === 'patch' || config.method === 'put' || config.method === 'delete') {
         Loading.show()
       }
+      config.headers.warehouse_id = LocalStorage.getItem('warehouse_id')
       return config
     } else {
       Loading.hide()

--- a/templates/src/layouts/MainLayout.vue
+++ b/templates/src/layouts/MainLayout.vue
@@ -743,6 +743,7 @@ export default {
       lang: this.$i18n.locale,
       container_height: this.$q.screen.height + '' + 'px',
       warehouse_name: '',
+      warehouse_id: '',
       warehouseOptions: [],
       langOptions: [
         { value: 'en-US', label: 'English' },
@@ -1011,16 +1012,27 @@ export default {
         .then((res) => {
           if (res.count === 1) {
             _this.openid = res.results[0].openid
+            _this.warehouse_id = res.results[0].id
             _this.warehouse_name = res.results[0].warehouse_name
+            LocalStorage.set('warehouse_id', _this.warehouse_id)
             LocalStorage.set('openid', _this.openid)
           } else {
             _this.warehouseOptions = res.results
-            if (LocalStorage.has('openid')) {
+            if (LocalStorage.has('warehouse_id')) {
+              _this.warehouse_id = LocalStorage.getItem('warehouse_id')
               _this.warehouseOptions.forEach((item, index) => {
-                if (item.openid === LocalStorage.getItem('openid')) {
+                if (item.id == _this.warehouse_id) {
                   _this.warehouse_name = item.warehouse_name
                 }
               })
+            } else if (LocalStorage.has('openid')) {
+              _this.warehouseOptions.forEach((item, index) => {
+                if (item.openid === LocalStorage.getItem('openid')) {
+                  _this.warehouse_name = item.warehouse_name
+                  _this.warehouse_id = item.id
+                }
+              })
+              LocalStorage.set('warehouse_id', _this.warehouse_id)
             }
           }
         })
@@ -1036,15 +1048,8 @@ export default {
     warehouseChange (e) {
       var _this = this
       _this.warehouse_name = _this.warehouseOptions[e].warehouse_name
-      _this.openid = _this.warehouseOptions[e].openid
-      LocalStorage.set('openid', _this.openid)
-      LocalStorage.set('staff_type', 'Admin')
-      _this.login_name = ''
-      LocalStorage.set('login_name', '')
-      _this.authin = '0'
-      _this.isLoggedIn()
-      LocalStorage.remove('auth')
-      SessionStorage.remove('axios_check')
+      _this.warehouse_id = _this.warehouseOptions[e].id
+      LocalStorage.set('warehouse_id', _this.warehouse_id)
     },
     langChange (e) {
       var _this = this
@@ -1069,6 +1074,9 @@ export default {
     } else {
       _this.openid = ''
       LocalStorage.set('openid', '')
+    }
+    if (LocalStorage.has('warehouse_id')) {
+      _this.warehouse_id = LocalStorage.getItem('warehouse_id')
     }
     if (LocalStorage.has('login_name')) {
       _this.login_name = LocalStorage.getItem('login_name')


### PR DESCRIPTION
## Summary
- keep user auth when changing warehouse
- store the selected `warehouse_id` in localStorage
- send `warehouse_id` with API requests

## Testing
- `python -m pip install -r requirements.txt` *(fails: twisted-iocpsupport wheel build error)*
- `python manage.py test` *(fails: Django not installed due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68831576c420833084812f7323d1c4dd